### PR TITLE
Fix zoom slider appearance in dist build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,9 @@ var config = {
       loader: ExtractTextPlugin.extract('style', 'css')
     }, {
       test: /\.less$/,
-      loader: ExtractTextPlugin.extract('style', ['css', 'less'])
+      // The mergeRules transformation breaks our zoom slider thumb.
+      // https://github.com/ben-eb/postcss-merge-rules/issues/18
+      loader: ExtractTextPlugin.extract('style', ['css?-mergeRules', 'less'])
     }, {
       test: /\.(png|jpg)$/,
       loader: 'url?limit=8192'


### PR DESCRIPTION
This is a workaround waiting for a proper fix (issue:
ben-eb/postcss-merge-rules#18).

Fixes #7
